### PR TITLE
String::_source open_basedir pre-check for urandom

### DIFF
--- a/util/String.php
+++ b/util/String.php
@@ -123,7 +123,7 @@ class String {
 		switch (true) {
 			case isset(static::$_source):
 				return static::$_source;
-			case is_readable('/dev/urandom') && $fp = fopen('/dev/urandom', 'rb'):
+			case !ini_get('open_basedir') && is_readable('/dev/urandom') && $fp = fopen('/dev/urandom', 'rb'):
 				return static::$_source = function($bytes) use (&$fp) {
 					return fread($fp, $bytes);
 				};


### PR DESCRIPTION
Requires open_basedir to be unset in order to use /dev/urandom.  Prevents "is_readable(): open_basedir restriction in effect. File(/dev/urandom) is not within the allowed path(s)" error.  This is the proper way to handle this case instead of silencing is_readable.